### PR TITLE
allow any argument to handler in DiscordListener

### DIFF
--- a/src/interaces/discord-module-register-options.ts
+++ b/src/interaces/discord-module-register-options.ts
@@ -3,7 +3,7 @@ import { DiscordClientEvent } from '../types/client-event';
 
 export interface DiscordListener {
   eventName: DiscordClientEvent;
-  handler: () => void;
+  handler: (...args: any) => void;
 }
 
 export interface DiscordModuleRegisterOptions {


### PR DESCRIPTION
example:
```
import { DiscordListener as IDiscordListener } from 'nest-discord-module/src/interaces/discord-module-register-options'
import { DiscordClientEvent } from 'nest-discord-module/src/types/client-event'

export class DiscordListener implements IDiscordListener{
  eventName: DiscordClientEvent = "message"

  async handler(message: Message){
  }
}
```